### PR TITLE
Add detection of sentiment in comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -35,6 +35,12 @@
         <artifactId>appengine-api-1.0-sdk</artifactId>
         <version>1.9.59</version>
     </dependency>
+
+    <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-language</artifactId>
+        <version>1.55.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,6 +32,7 @@ import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.cloud.language.v1.Sentiment;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
+//An object that will be converted to JSON. Contains comments and their sentiment scores
 class CommentSentiment {
     ArrayList<String> comments;
     ArrayList<Double> scores;
@@ -46,12 +47,9 @@ class CommentSentiment {
 public class DataServlet extends HttpServlet {
 
     //Loads comments every time page is loaded
-    
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json");
-        //ArrayList<String> comments = new ArrayList<>();
-        //ArrayList<Integer> scores = new ArrayList<>();
 
         CommentSentiment commentSentiment = 
             new CommentSentiment(new ArrayList<String>(), new ArrayList<Double>());
@@ -63,18 +61,12 @@ public class DataServlet extends HttpServlet {
         for (Entity entity : results.asIterable()) {
             String comment = (String) entity.getProperty("comment");
             Double score = (Double) entity.getProperty("sentiment");
-            //comments.add(comment);
-            //scores.add(score);
             commentSentiment.comments.add(comment);
             commentSentiment.scores.add(score);
         }
 
-
-        Gson gson = new Gson();
-        String jsonComments = gson.toJson(commentSentiment);
-        //String jsonScores = gson.toJson(scores);
+        String jsonComments = new Gson().toJson(commentSentiment);
         response.getWriter().println(jsonComments);
-        //response.getWriter().println(scores);
     }
 
     //Adds a comment every time someone posts
@@ -82,6 +74,7 @@ public class DataServlet extends HttpServlet {
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String comment = request.getParameter("comment");
 
+        //Gets the sentiment score based on the comment
         Document doc =
             Document.newBuilder().setContent(comment).setType(Document.Type.PLAIN_TEXT).build();
         LanguageServiceClient languageService = LanguageServiceClient.create();
@@ -89,6 +82,7 @@ public class DataServlet extends HttpServlet {
         float score = sentiment.getScore();
         languageService.close();
 
+        //Stores the comment, sentiment, and time of submission
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Entity commentEntity = new Entity("Comment");
         commentEntity.setProperty("comment", comment);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -31,18 +31,19 @@ import com.google.cloud.language.v1.Document;
 import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.cloud.language.v1.Sentiment;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
-//An object that will be converted to JSON. Contains comments and their sentiment scores
+
+/**An object that will be converted to JSON. Contains comments and their sentiment scores */
 class CommentSentiment {
     ArrayList<String> comments;
     ArrayList<Double> scores;
 
-    CommentSentiment(ArrayList<String> c, ArrayList<Double> s) {
-        this.comments = c;
-        this.scores = s;
+    CommentSentiment() {
+        this.comments = new ArrayList<String>();
+        this.scores = new ArrayList<Double>();
     }
 }
 
+/** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
@@ -51,8 +52,7 @@ public class DataServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json");
 
-        CommentSentiment commentSentiment = 
-            new CommentSentiment(new ArrayList<String>(), new ArrayList<Double>());
+        CommentSentiment commentSentiment = new CommentSentiment();
         
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -20,7 +20,7 @@ function getMessage() {
     fetch("/data").then(response => response.json()).then(responseObj => {
         var commentString = "\n"; //Initializing string containing comments
 
-        //Converts the array argument to string form for display
+        //Converts the JSON object argument to string form for display
         for(comment in responseObj.comments) {
             var commentOrder = responseObj.comments.length - comment;
             var score = responseObj.scores[comment];
@@ -28,6 +28,7 @@ function getMessage() {
 
             commentString = commentString + "Comment " + commentOrder;
 
+            //Attributing sentiment based on sentiment scores
             if (score > 0.4) {
                 sentimentStr = "(Positive Sentiment)";
             } else if (score < -0.4) {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -17,14 +17,27 @@ function displayText(pageType) {
 }
 
 function getMessage() {
-    fetch("/data").then(response => response.json()).then(commentArray => {
+    fetch("/data").then(response => response.json()).then(responseObj => {
         var commentString = "\n"; //Initializing string containing comments
 
         //Converts the array argument to string form for display
-        for(comment in commentArray) {
-            var commentOrder = commentArray.length - comment;
-            commentString = commentString + "Comment " + commentOrder + ":\n";
-            commentString = commentString + commentArray[comment] + "\n\n";
+        for(comment in responseObj.comments) {
+            var commentOrder = responseObj.comments.length - comment;
+            var score = responseObj.scores[comment];
+            var sentimentStr;
+
+            commentString = commentString + "Comment " + commentOrder;
+
+            if (score > 0.4) {
+                sentimentStr = "(Positive Sentiment)";
+            } else if (score < -0.4) {
+                sentimentStr = "(Negative Sentiment)";
+            } else {
+                sentimentStr = "(Neutral Sentiment)";
+            }
+
+            commentString = commentString + " " + sentimentStr + ":\n";
+            commentString = commentString + responseObj.comments[comment] + "\n\n";
         }
 
         document.getElementById("message-container").innerText = commentString;


### PR DESCRIPTION
I've added a sentiment feature using Google's Cloud Natural Language API. Now, beside each comment is a written indication of whether the comment is positive, negative, or neutral in its sentiment. The indications are obtained by meeting a threshold in the NLP API's sentiment scores (which range from -1 to 1; 1 being the most positive).

 I made changes to the Java Servlet so that it now converts an object to JSON. The object contains an array of strings (for the comments themselves) and an array of doubles (for the sentiment on a scale of -1 to 1). Previously, I had converted and passed only an array of comments. The scores are also now stored persistently with the comments. The javascript file reflects these changes to correctly display sentiment. 